### PR TITLE
SCRUM-3728 Directory reload bugfix

### DIFF
--- a/src/Framework/N2/Edit/FileSystem/IFileSystem.cs
+++ b/src/Framework/N2/Edit/FileSystem/IFileSystem.cs
@@ -12,7 +12,8 @@ namespace N2.Edit.FileSystem
         /// <summary>Gets files in directory.</summary>
         /// <param name="parentVirtualPath">The path to the directory.</param>
         /// <returns>An enumerations of files in the directory.</returns>
-        IEnumerable<FileData> GetFiles(string parentVirtualPath); 
+        IEnumerable<FileData> GetFiles(string parentVirtualPath);
+        IEnumerable<FileData> GetFiles(string parentVirtualPath, bool getFromCache);
 
         /// <summary>Gets file data.</summary>
         /// <param name="virtualPath">The path to the file.</param>
@@ -23,6 +24,7 @@ namespace N2.Edit.FileSystem
         /// <param name="parentVirtualPath">The path to the directory whose child directories to get.</param>
         /// <returns>An enumeration of directories.</returns>
         IEnumerable<DirectoryData> GetDirectories(string parentVirtualPath);
+        IEnumerable<DirectoryData> GetDirectories(string parentVirtualPath, bool getFromCache);
 
         /// <summary>Gets a directory data.</summary>
         /// <param name="virtualPath">The path of the directory to get.</param>

--- a/src/Framework/N2/Edit/FileSystem/MappedFileSystem.cs
+++ b/src/Framework/N2/Edit/FileSystem/MappedFileSystem.cs
@@ -25,6 +25,11 @@ namespace N2.Edit.FileSystem
                 if(!file.Name.StartsWith("."))
                     yield return GetFile(N2.Web.Url.Combine(parentVirtualPath, file.Name), file);
         }
+        public IEnumerable<FileData> GetFiles(string parentVirtualPath, bool getFromCache)
+        {
+            //cache is not implemented just return method without.
+            return GetFiles(parentVirtualPath);
+        }
 
         public FileData GetFile(string virtualPath)
         {
@@ -56,6 +61,11 @@ namespace N2.Edit.FileSystem
             foreach (var dir in new DirectoryInfo(path).GetDirectories())
                 if (!dir.Name.StartsWith("."))
                     yield return GetDirectory(N2.Web.Url.Combine(parentVirtualPath, dir.Name), dir);
+        }
+        public IEnumerable<DirectoryData> GetDirectories(string parentVirtualPath, bool getFromCache)
+        {
+            //cache is not implemented just return method without.
+            return GetDirectories(parentVirtualPath);
         }
 
         public DirectoryData GetDirectory(string virtualPath)

--- a/src/Framework/N2/Edit/FileSystem/NH/DatabaseFileSystem.cs
+++ b/src/Framework/N2/Edit/FileSystem/NH/DatabaseFileSystem.cs
@@ -75,6 +75,11 @@ namespace N2.Edit.FileSystem.NH
             return from child in FindChildren(path, Restrictions.IsNotNull("Length"))
                    select child.ToFileData();
         }
+        public IEnumerable<FileData> GetFiles(string parentVirtualPath, bool getFromCache)
+        {
+            //cache is not implemented just return method without.
+            return GetFiles(parentVirtualPath);
+        }
 
         public FileData GetFile(string virtualPath)
         {
@@ -92,6 +97,11 @@ namespace N2.Edit.FileSystem.NH
 
             return from child in FindChildren(path, Restrictions.IsNull("Length"))
                    select child.ToDirectoryData();
+        }
+        public IEnumerable<DirectoryData> GetDirectories(string parentVirtualPath, bool getFromCache)
+        {
+            //cache is not implemented just return method without.
+            return GetDirectories(parentVirtualPath);
         }
 
         public DirectoryData GetDirectory(string virtualPath)

--- a/src/Framework/N2/Edit/FileSystem/VirtualPathFileSystem.cs
+++ b/src/Framework/N2/Edit/FileSystem/VirtualPathFileSystem.cs
@@ -29,6 +29,11 @@ namespace N2.Edit.FileSystem
             foreach (VirtualFile file in PathProvider.GetDirectory(parentVirtualPath).Files)
                 yield return GetFile(file.VirtualPath);
         }
+        public virtual IEnumerable<FileData> GetFiles(string parentVirtualPath, bool getFromCache)
+        {
+            //cache is not implemented just return method without.
+            return GetFiles(parentVirtualPath);
+        }
 
         /// <summary>Gets file data.</summary>
         /// <param name="virtualPath">The path to the file.</param>
@@ -65,6 +70,11 @@ namespace N2.Edit.FileSystem
 
             foreach (VirtualDirectory dir in PathProvider.GetDirectory(parentVirtualPath).Directories)
                 yield return GetDirectory(dir.VirtualPath);
+        }
+        public virtual IEnumerable<DirectoryData> GetDirectories(string parentVirtualPath, bool getFromCache)
+        {
+            //cache is not implemented just return method without.
+            return GetDirectories(parentVirtualPath);
         }
 
         /// <summary>Gets a directory data.</summary>

--- a/src/Framework/N2/Resources/Register.cs
+++ b/src/Framework/N2/Resources/Register.cs
@@ -58,8 +58,8 @@ namespace N2.Resources
 		public const string AngularJsVersion = "1.5.8";
 		public const string CkEditorVersion = "4.5.8";
 		public const string DefaultBootstrapVersion = "2.3.2";
-		public const string ScriptVersion = "202109141021";
-		public const string CssVersion = "202112221710";
+		public const string ScriptVersion = "202203140939";
+		public const string CssVersion = "202203091427";
 
 		public const string DefaultFlagsCssPath = "{ManagementUrl}/Resources/icons/flags.css?v="+CssVersion;
 		public const string DefaultJQueryJsPath = "//code.jquery.com/jquery-" + JQueryVersion + ".min.js";

--- a/src/Framework/Tests/Fakes/FakeMemoryFileSystem.cs
+++ b/src/Framework/Tests/Fakes/FakeMemoryFileSystem.cs
@@ -16,6 +16,11 @@ namespace N2.Tests.Fakes
         {
             return files.Keys.Where(k => k.StartsWith(parentVirtualPath)).Select(k => files[k]);
         }
+        public IEnumerable<FileData> GetFiles(string parentVirtualPath, bool getFromCache)
+        {
+            //cache is not implemented just return method without.
+            return GetFiles(parentVirtualPath);
+        }
 
         public FileData GetFile(string virtualPath)
         {
@@ -25,6 +30,11 @@ namespace N2.Tests.Fakes
         public IEnumerable<DirectoryData> GetDirectories(string parentVirtualPath)
         {
             return directories.Keys.Where(k => k.StartsWith(parentVirtualPath)).Select(k => directories[k]);
+        }
+        public IEnumerable<DirectoryData> GetDirectories(string parentVirtualPath, bool getFromCache)
+        {
+            //cache is not implemented just return method without.
+            return GetDirectories(parentVirtualPath);
         }
 
         public DirectoryData GetDirectory(string virtualPath)

--- a/src/Mvc/MvcTemplates/N2/Content/Navigation/MediaBrowser.aspx
+++ b/src/Mvc/MvcTemplates/N2/Content/Navigation/MediaBrowser.aspx
@@ -60,6 +60,7 @@
                     </div><!-- /input-group -->
                 </div>
                 <span class="input-group-btn" style="text-align:right;padding:0 10px 0 0;">
+                    <button id="btn-reload" class="btn btn-default" type="button" title="Reload" style="margin-right:25px;"><span class="glyphicon glyphicon-repeat" style="margin-right:5px;"></span> Reload</button>
                     <button id="btn-view-grid" class="btn btn-default" type="button" title="Grid View"><span class="glyphicon glyphicon-th"></span></button>
                     <button id="btn-view-list" class="btn btn-default" type="button" title="List View"><span class="glyphicon glyphicon-list"></span></button>
 		            <script>
@@ -72,8 +73,22 @@
                                 e.preventDefault();
                                 $("#browser-files-list-ul").addClass('media-browser');
                             });
+                            $("#btn-reload").click(function (e) {
+                                e.preventDefault();
+                                var $btn = $(this);
+                                $btn.prop("disabled", true);//prevent multiple clicks
+                                $("#btn-reload .glyphicon-repeat").addClass('spinning');//start spinning animation
+                                var curPath = n2MediaBrowser.getCurPath();
+                                $.post('/filesystemreload.n2.ashx', { action: 'filesystemreload', selected: curPath }, function () {
+                                    n2MediaBrowser.loadData(curPath, null);//reload the page after success refresh
+                                }).always(function () {
+                                    //do the following after reload ajax call finish regardless of success or fail.
+                                    $("#btn-reload .glyphicon-repeat").removeClass('spinning');//stop spinning animation
+                                    $btn.prop("disabled", false);//re-enable reload button
+                                });
+                            });
                         });
-		            </script>
+                    </script>
                 </span>
             </div>
 

--- a/src/Mvc/MvcTemplates/N2/Content/Navigation/MediaBrowser.js
+++ b/src/Mvc/MvcTemplates/N2/Content/Navigation/MediaBrowser.js
@@ -54,6 +54,7 @@
         patternInfoFile: "<label>{{i18url}}</label>{{url}}",
         preferredSize: "",
         lastPath: "",
+        curPath: "",
         divBreadcrumb: null,
         history: { breadcrumb: "", list: "" },
         ajaxUrl: "",
@@ -97,6 +98,7 @@
             };
             me.preferredSize = me.list.getAttribute("data-preferredsize");
             me.lastPath = me.list.getAttribute("data-path");
+            me.curPath = me.list.getAttribute("data-path");
             me.selectedUrl = me.list.getAttribute("data-selurl");
 
             if (me.list != null) {
@@ -352,7 +354,7 @@
         loadData: function (newDir, searchText) {
             var me = fileBrowser,
                 ajaxUrl = me.ajaxUrl;
-
+            fileBrowser.curPath = newDir;
             fileBrowser.showCreateDirectory = !Boolean(searchText);
             me.api.getData(ajaxUrl, newDir, searchText, window.selectableExtensions, me.repaintList);
         },
@@ -867,7 +869,11 @@
     fileBrowser.init();
 
     return {
-        api: fileBrowser.api
+        api: fileBrowser.api,
+        loadData: fileBrowser.loadData,
+        getCurPath: function () {
+            return fileBrowser.curPath;
+        },
     }
 
 

--- a/src/Mvc/MvcTemplates/N2/Files/FileSystem/Directory.aspx
+++ b/src/Mvc/MvcTemplates/N2/Files/FileSystem/Directory.aspx
@@ -35,15 +35,16 @@
                     $("#directory-container").addClass('upload-folder');
                 });
                 $("#btn-reload").click(function (e) {
-                    e.preventDefault();
-                    $(this).prop("disabled", true);//prevent multiple clicks
+					e.preventDefault();
+					var $btn = $(this);
+                    $btn.prop("disabled", true);//prevent multiple clicks
                     $("#btn-reload .glyphicon-repeat").addClass('spinning');//start spinning animation
                     $.post('/filesystemreload.n2.ashx', { action: 'filesystemreload', selected: '<%=(Selection.SelectedItem as N2.Edit.FileSystem.Items.Directory)?.LocalUrl%>' }, function () {
                         location.reload();//reload the page after success refresh
-                    }).always(function () {
-                        //do the following after reload ajax call finish regardless of success or fail.
+                    }).fail(function () {
+                        //do the following after reload ajax call fails and does not reload the page.
                         $("#btn-reload .glyphicon-repeat").removeClass('spinning');//stop spinning animation
-                        $(this).prop("disabled", false);//re-enable reload button
+                        $btn.prop("disabled", false);//re-enable reload button
                     });
                 });
 			});

--- a/src/Mvc/MvcTemplates/N2/Files/FileSystem/Directory.aspx
+++ b/src/Mvc/MvcTemplates/N2/Files/FileSystem/Directory.aspx
@@ -14,7 +14,6 @@
         <asp:LinkButton ID="btnAdd" runat="server" Text="Add selected" CssClass="command primary-action" OnCommand="OnAddCommand" OnClientClick="return confirm('Add selected files?');" meta:resourceKey="btnAdd" Visible="false"/>
 		<asp:HyperLink ID="hlEdit" runat="server" Text="Edit" CssClass="command edit" meta:resourceKey="hlEdit" />
         <asp:HyperLink ID="hlCancel" runat="server" Text="Close" CssClass="btn" meta:resourceKey="hlCancel" Visible="false"/>
-        
 	</edit:ButtonGroup>
 </asp:Content>
 <asp:Content ContentPlaceHolderID="Content" runat="server">
@@ -22,6 +21,7 @@
                 var url = Url.Parse("Directory.aspx").AppendSelection(node);
         %>/<a href="<%= string.Format("{0}{1}{2}", url, string.IsNullOrEmpty(ParentQueryString) ? "" : url.ToString().Contains("?") ? "&" : "?", ParentQueryString) %>"><%= node.Title %></a><% } %></h1>
 	<span class="input-group-btn" style="text-align:right;padding:0 10px 10px 0;">
+        <button id="btn-reload" class="btn btn-default" type="button" title="Reload" style="margin-right:25px;"><span class="glyphicon glyphicon-repeat" style="margin-right:5px;"></span> Reload</button>
         <button id="btn-view-grid" class="btn btn-default" type="button" title="Grid View"><span class="glyphicon glyphicon-th"></span></button>
         <button id="btn-view-list" class="btn btn-default" type="button" title="List View"><span class="glyphicon glyphicon-list"></span></button>
 		<script>
@@ -32,16 +32,29 @@
 				});
 				$("#btn-view-list").click(function (e) {
 					e.preventDefault();
-					$("#directory-container").addClass('upload-folder');
-				});
+                    $("#directory-container").addClass('upload-folder');
+                });
+                $("#btn-reload").click(function (e) {
+                    e.preventDefault();
+                    $(this).prop("disabled", true);//prevent multiple clicks
+                    $("#btn-reload .glyphicon-repeat").addClass('spinning');//start spinning animation
+                    $.post('/filesystemreload.n2.ashx', { action: 'filesystemreload', selected: '<%=(Selection.SelectedItem as N2.Edit.FileSystem.Items.Directory)?.LocalUrl%>' }, function () {
+                        location.reload();//reload the page after success refresh
+                    }).always(function () {
+                        //do the following after reload ajax call finish regardless of success or fail.
+                        $("#btn-reload .glyphicon-repeat").removeClass('spinning');//stop spinning animation
+                        $(this).prop("disabled", false);//re-enable reload button
+                    });
+                });
 			});
-		</script>
+        </script>
     </span>
 	<div style="clear:both;"></div>
 	<div class="tabPanel" data-flag="Unclosable">
         <edit:PermissionPanel id="ppPermitted" RequiredPermission="Write" runat="server" meta:resourceKey="ppPermitted">
 			<edit:FileUpload runat="server" />
 		</edit:PermissionPanel>
+
         <div id="directory-container" class="directory cf">
             <a href ="<%= GetEditUrl() %>">
             <div data-i="0" class="file create-new-folder">
@@ -76,53 +89,5 @@
 			    </ItemTemplate>
 		    </asp:Repeater>
 	    </div>
-
     </div>
-
-<style>
-    .create-new-folder {
-    position:relative;
-}
-.create-new-folder label {
-    position: absolute;
-    bottom: 0;
-    left: 0;
-    right: 0;
-    background: none !important;
-    display: block;
-    margin: 0;
-    font-weight: bold;
-    font-size: 10px;
-    height:25px !important;
-    text-align:center;
-}
-.file .file-ic {
-    position: absolute;
-    top: 25px;
-    left: 0;
-    right: 0;
-    text-align: center;
-    font-size: 25px;
-}
-.glyphicon-folder-plus {
-    background: url('/N2/Resources/img/folder_plus.gif') no-repeat center center;
-    height: 30px;
-}
-
-.glyphicon {
-    position: relative;
-    top: 1px;
-    display: inline-block;
-    font-family: 'Glyphicons Halflings';
-    font-style: normal;
-    font-weight: 400;
-    line-height: 1;
-    -webkit-font-smoothing: antialiased;
-    -moz-osx-font-smoothing: grayscale;
-}
-
-.file.create-new-folder {
-    background: #a1d4fe;
-}
-</style>
 </asp:Content>

--- a/src/Mvc/MvcTemplates/N2/Files/FileSystem/Directory.aspx.cs
+++ b/src/Mvc/MvcTemplates/N2/Files/FileSystem/Directory.aspx.cs
@@ -1,27 +1,23 @@
+using N2.Collections;
+using N2.Configuration;
+using N2.Edit.FileSystem.Items;
+using N2.Edit.Navigation;
+using N2.Edit.Versioning;
+using N2.Edit.Web;
+using N2.Engine;
+using N2.Persistence;
+using N2.Resources;
+using N2.Web;
+using N2.Web.Drawing;
 using System;
 using System.Collections.Generic;
 using System.Linq;
-using System.Web.UI.WebControls;
-using N2.Edit.FileSystem.Items;
-using N2.Edit.Web;
-using N2.Resources;
-using N2.Web.Drawing;
-using System.Configuration;
-using System.Web.Configuration;
-using N2.Web;
 using System.Web;
-using N2.Edit.Navigation;
-using N2.Collections;
-
-using N2.Configuration;
-using N2.Edit.Versioning;
-using N2.Persistence;
-using N2.Definitions;
-using N2.Edit;
+using System.Web.UI.WebControls;
 
 namespace N2.Edit.FileSystem
 {
-	public partial class Directory1 : EditPage
+    public partial class Directory1 : EditPage
 	{
 		protected bool IsMultiUpload, IsAllowed;
 		protected string ParentQueryString = "";
@@ -311,5 +307,5 @@ namespace N2.Edit.FileSystem
             return url.AppendQuery("returnUrl", Request["returnUrl"]);
         }
 
-    }
+	}
 }

--- a/src/Mvc/MvcTemplates/N2/Files/FileSystem/Directory.aspx.designer.cs
+++ b/src/Mvc/MvcTemplates/N2/Files/FileSystem/Directory.aspx.designer.cs
@@ -7,11 +7,13 @@
 // </auto-generated>
 //------------------------------------------------------------------------------
 
-namespace N2.Edit.FileSystem {
-    
-    
-    public partial class Directory1 {
-        
+namespace N2.Edit.FileSystem
+{
+
+
+    public partial class Directory1
+    {
+
         /// <summary>
         /// btnDelete control.
         /// </summary>
@@ -20,7 +22,7 @@ namespace N2.Edit.FileSystem {
         /// To modify move field declaration from designer file to code-behind file.
         /// </remarks>
         protected global::System.Web.UI.WebControls.LinkButton btnDelete;
-        
+
         /// <summary>
         /// btnAdd control.
         /// </summary>
@@ -29,7 +31,7 @@ namespace N2.Edit.FileSystem {
         /// To modify move field declaration from designer file to code-behind file.
         /// </remarks>
         protected global::System.Web.UI.WebControls.LinkButton btnAdd;
-        
+
         /// <summary>
         /// hlEdit control.
         /// </summary>
@@ -38,7 +40,7 @@ namespace N2.Edit.FileSystem {
         /// To modify move field declaration from designer file to code-behind file.
         /// </remarks>
         protected global::System.Web.UI.WebControls.HyperLink hlEdit;
-        
+
         /// <summary>
         /// hlCancel control.
         /// </summary>
@@ -47,7 +49,7 @@ namespace N2.Edit.FileSystem {
         /// To modify move field declaration from designer file to code-behind file.
         /// </remarks>
         protected global::System.Web.UI.WebControls.HyperLink hlCancel;
-        
+
         /// <summary>
         /// ppPermitted control.
         /// </summary>
@@ -56,7 +58,7 @@ namespace N2.Edit.FileSystem {
         /// To modify move field declaration from designer file to code-behind file.
         /// </remarks>
         protected global::N2.Edit.Web.UI.Controls.PermissionPanel ppPermitted;
-        
+
         /// <summary>
         /// rptDirectories control.
         /// </summary>
@@ -65,7 +67,7 @@ namespace N2.Edit.FileSystem {
         /// To modify move field declaration from designer file to code-behind file.
         /// </remarks>
         protected global::System.Web.UI.WebControls.Repeater rptDirectories;
-        
+
         /// <summary>
         /// rptFiles control.
         /// </summary>

--- a/src/Mvc/MvcTemplates/N2/Files/FileSystem/FileSystemReload.cs
+++ b/src/Mvc/MvcTemplates/N2/Files/FileSystem/FileSystemReload.cs
@@ -1,0 +1,48 @@
+﻿using N2.Edit.FileSystem;
+using N2.Engine;
+using N2.Web;
+using System.Web;
+
+namespace N2.Management.Files.FileSystem
+{
+	[Service(typeof(IAjaxService))]
+	public class FileSystemReload : IAjaxService
+	{
+		private readonly IFileSystem fs;
+		private readonly IEngine engine;
+
+		public FileSystemReload(IFileSystem fs, IEngine engine)
+		{
+			this.fs = fs;
+			this.engine = engine;
+		}
+
+		public string Name
+		{
+			get { return "filesystemreload"; }
+		}
+
+		public bool RequiresEditAccess
+		{
+			get { return true; }
+		}
+
+		public bool IsValidHttpMethod(string httpMethod)
+		{
+			return true;
+		}
+
+		public void Handle(HttpContextBase context)
+		{
+			if (fs == null) return;
+
+			string selected = context.Request["selected"];
+			if (string.IsNullOrWhiteSpace(selected)) return;
+
+			//Calling method to not load from cache will reload fresh data into cache for the next call on Reload()
+			fs.GetDirectories(selected, false);
+			fs.GetFiles(selected, false);
+
+		}
+	}
+}

--- a/src/Mvc/MvcTemplates/N2/N2.Management.csproj
+++ b/src/Mvc/MvcTemplates/N2/N2.Management.csproj
@@ -663,6 +663,7 @@
     <Compile Include="Files\FileSystem\File.aspx.designer.cs">
       <DependentUpon>File.aspx</DependentUpon>
     </Compile>
+    <Compile Include="Files\FileSystem\FileSystemReload.cs" />
     <Compile Include="Files\FileSystem\FileUpload.ascx.cs">
       <DependentUpon>FileUpload.ascx</DependentUpon>
       <SubType>ASPXCodeBehind</SubType>

--- a/src/Mvc/MvcTemplates/N2/Resources/Css/framed.css
+++ b/src/Mvc/MvcTemplates/N2/Resources/Css/framed.css
@@ -308,7 +308,7 @@ input.dp-applied {
 			text-overflow:ellipsis;
 			white-space: nowrap;
         }
-    .droparea, .pickarea { margin:20px 0 0 0; padding:10px; clear:both; opacity:.5; background-color:#f8f8f8; border:none; }
+    .droparea, .pickarea { margin: 0 0 20px 0; padding:10px; clear:both; opacity:.5; background-color:#f8f8f8; border:none; }
     .droparea:hover, .pickarea:hover { opacity:1; }
         .droparea em, .pickarea em { margin-left:10px; display:none; }
         .droparea:hover em, .pickarea:hover em  { display:inline; }
@@ -443,4 +443,107 @@ input.dp-applied {
 
 .media-browser.files-list .file.image label {
 	display: unset;
+}
+
+.create-new-folder {
+	position: relative;
+}
+
+.create-new-folder label {
+	position: absolute;
+	bottom: 0;
+	left: 0;
+	right: 0;
+	background: none !important;
+	display: block;
+	margin: 0;
+	font-weight: bold;
+	font-size: 10px;
+	height: 25px !important;
+	text-align: center;
+}
+
+.file .file-ic {
+	position: absolute;
+	top: 25px;
+	left: 0;
+	right: 0;
+	text-align: center;
+	font-size: 25px;
+}
+
+.glyphicon-folder-plus {
+	background: url('/N2/Resources/img/folder_plus.gif') no-repeat center center;
+	height: 30px;
+}
+
+.glyphicon {
+	position: relative;
+	top: 1px;
+	display: inline-block;
+	font-family: 'Glyphicons Halflings';
+	font-style: normal;
+	font-weight: 400;
+	line-height: 1;
+	-webkit-font-smoothing: antialiased;
+	-moz-osx-font-smoothing: grayscale;
+}
+
+.file.create-new-folder {
+	background: #a1d4fe;
+}
+
+.spinning {
+	-webkit-animation-name: spin;
+	-webkit-animation-duration: 2000ms;
+	-webkit-animation-iteration-count: infinite;
+	-webkit-animation-timing-function: linear;
+	-moz-animation-name: spin;
+	-moz-animation-duration: 2000ms;
+	-moz-animation-iteration-count: infinite;
+	-moz-animation-timing-function: linear;
+	-ms-animation-name: spin;
+	-ms-animation-duration: 2000ms;
+	-ms-animation-iteration-count: infinite;
+	-ms-animation-timing-function: linear;
+	animation-name: spin;
+	animation-duration: 2000ms;
+	animation-iteration-count: infinite;
+	animation-timing-function: linear;
+}
+
+@-ms-keyframes spin {
+	from {
+		-ms-transform: rotate(0deg);
+	}
+	to {
+		-ms-transform: rotate(359deg);
+	}
+}
+
+@-moz-keyframes spin {
+	from {
+		-moz-transform: rotate(0deg);
+	}
+	to {
+		-moz-transform: rotate(359deg);
+	}
+}
+
+@-webkit-keyframes spin {
+	from {
+		-webkit-transform: rotate(0deg);
+	}
+	to {
+		-webkit-transform: rotate(359deg);
+	}
+}
+
+@keyframes spin {
+	from {
+		transform: rotate(0deg);
+	}
+	to {
+		transform: rotate(359deg);
+	}
 }


### PR DESCRIPTION
For the Directory page...

Reload button will stay disabled and spin animation will continue until the page is refreshed instead of stopping after ajax call is finished since there's a delay between ajax call finish and the actual page refresh.

If ajax call fails the button will be re-enabled and spin animation will stop so the user knows it stopped processing and can try again.