### PR TITLE
SCRUM-3728 Directory reload bugfix

### DIFF
--- a/src/Mvc/MvcTemplates/N2/Files/FileSystem/Directory.aspx
+++ b/src/Mvc/MvcTemplates/N2/Files/FileSystem/Directory.aspx
@@ -35,15 +35,16 @@
                     $("#directory-container").addClass('upload-folder');
                 });
                 $("#btn-reload").click(function (e) {
-                    e.preventDefault();
-                    $(this).prop("disabled", true);//prevent multiple clicks
+					e.preventDefault();
+					var $btn = $(this);
+                    $btn.prop("disabled", true);//prevent multiple clicks
                     $("#btn-reload .glyphicon-repeat").addClass('spinning');//start spinning animation
                     $.post('/filesystemreload.n2.ashx', { action: 'filesystemreload', selected: '<%=(Selection.SelectedItem as N2.Edit.FileSystem.Items.Directory)?.LocalUrl%>' }, function () {
                         location.reload();//reload the page after success refresh
-                    }).always(function () {
-                        //do the following after reload ajax call finish regardless of success or fail.
+                    }).fail(function () {
+                        //do the following after reload ajax call fails and does not reload the page.
                         $("#btn-reload .glyphicon-repeat").removeClass('spinning');//stop spinning animation
-                        $(this).prop("disabled", false);//re-enable reload button
+                        $btn.prop("disabled", false);//re-enable reload button
                     });
                 });
 			});


### PR DESCRIPTION
For the Directory page...

Reload button will stay disabled and spin animation will continue until the page is refreshed instead of stopping after ajax call is finished since there's a delay between ajax call finish and the actual page refresh.

If ajax call fails the button will be re-enabled and spin animation will stop so the user knows it stopped processing and can try again.