### PR TITLE
Command button configuration

### DIFF
--- a/docs/n2cms.configuration.xsd
+++ b/docs/n2cms.configuration.xsd
@@ -76,11 +76,11 @@
 																	</xs:complexType>
 																</xs:element>
 															</xs:sequence>
-                              <xs:attribute name="uploadsWhitelistExression" type="xs:string"/>
-                              <xs:attribute name="uploadsBlacklistExression" type="xs:string"/>
-                              <xs:attribute name="requiredPermissionToDelete" type="xs:string" use="optional" default="Publish" />
-                              <xs:attribute name="requiredPermissionToModify" type="xs:string" use="optional" default="Publish" />
-                            </xs:complexType>
+															<xs:attribute name="uploadsWhitelistExression" type="xs:string"/>
+															<xs:attribute name="uploadsBlacklistExression" type="xs:string"/>
+															<xs:attribute name="requiredPermissionToDelete" type="xs:string" use="optional" default="Publish" />
+															<xs:attribute name="requiredPermissionToModify" type="xs:string" use="optional" default="Publish" />
+														</xs:complexType>
 													</xs:element>
 												</xs:all>
 												<xs:attribute name="id" type="xs:integer" use="required" />
@@ -317,7 +317,7 @@
 										</xs:element>
 									</xs:sequence>
 									<xs:attribute name="enabled" type="xs:boolean" use="optional" />
-                  <xs:attribute name="runWhileDebuggerAttached" type="xs:boolean" use="optional" />
+									<xs:attribute name="runWhileDebuggerAttached" type="xs:boolean" use="optional" />
 									<xs:attribute name="asyncActions" type="xs:boolean" use="optional" />
 									<xs:attribute name="interval" type="xs:integer" use="optional" />
 									<xs:attribute name="keepAlive" type="xs:boolean" use="optional" />
@@ -325,11 +325,11 @@
 									<xs:attribute name="executeOnMachineNamed" type="xs:string" use="optional" />
 								</xs:complexType>
 							</xs:element>
-              <xs:element name="directUrlInjector" minOccurs="0">
-                <xs:complexType>
-                  <xs:attribute name="enabled" type="xs:boolean" use="optional" />
-                </xs:complexType>
-              </xs:element>
+							<xs:element name="directUrlInjector" minOccurs="0">
+								<xs:complexType>
+									<xs:attribute name="enabled" type="xs:boolean" use="optional" />
+								</xs:complexType>
+							</xs:element>
 							<xs:element name="components" minOccurs="0">
 								<xs:complexType>
 									<xs:sequence>
@@ -519,7 +519,7 @@
 						<xs:attribute name="caching" type="xs:boolean" use="optional" />
 						<xs:attribute name="tryLocatingHbmResources" type="xs:boolean" use="optional" />
 						<xs:attribute name="cacheProviderClass" type="xs:string" use="optional" />
-            <xs:attribute name="cacheExpiration" type="xs:string" use="optional"/>
+						<xs:attribute name="cacheExpiration" type="xs:string" use="optional"/>
 						<xs:attribute name="sqlCacheDependency" type="xs:string" use="optional" />
 						<xs:attribute name="cacheRegion" type="xs:string" use="optional" />
 						<xs:attribute name="connectionStringName" type="xs:string" use="optional" />
@@ -628,14 +628,14 @@
 										</xs:element>
 									</xs:all>
 									<xs:attribute name="ckConfigJsPath" type="xs:string" use="optional" default="~/N2/Resources/ckeditor/config.js" />
-                  <xs:attribute name="overwriteStylesSet" type="xs:string" use="optional" default="default" />
-                  <xs:attribute name="overwriteFormatTags" type="xs:string" use="optional" default="p;h1;h2;h3;pre" />
-                  <xs:attribute name="overwriteBasicToolBar" type="xs:string" use="optional" default="[{ name: 'clipboard', items : [ 'Cut','Copy','Paste','PasteText','PasteFromWord','-','Undo','Redo' ] }, '/', { name: 'basicstyles', items : [ 'Bold','Italic','Underline' ] },{ name: 'paragraph', items : [ 'NumberedList','BulletedList' ] }]" />
-                  <xs:attribute name="overwriteStandardToolBar" type="xs:string" use="optional" default="[{ name: 'clipboard', items : [ 'Cut','Copy','Paste','PasteText','PasteFromWord','-','Undo','Redo' ] }, { name: 'links', items : [ 'Link','Unlink','Anchor' ] }, { name: 'insert', items : [ 'Image','Table','HorizontalRule','SpecialChar' ] },{ name: 'tools', items : [ 'Maximize'] }, { name: 'document', items : [ 'Source'] }, '/', { name: 'basicstyles', items : [ 'Bold','Italic','Underline','Strike','Subscript','Superscript','-','RemoveFormat' ] }, { name: 'paragraph', items : [ 'NumberedList','BulletedList','-','Outdent','Indent','-','Blockquote' ] },{ name: 'styles', items : [ 'Styles','Format' ] }]" />
-                  <xs:attribute name="contentsCssPath" type="xs:string" use="optional" default="~/N2/Resources/ckeditor/contents.css" />
+									<xs:attribute name="overwriteStylesSet" type="xs:string" use="optional" default="default" />
+									<xs:attribute name="overwriteFormatTags" type="xs:string" use="optional" default="p;h1;h2;h3;pre" />
+									<xs:attribute name="overwriteBasicToolBar" type="xs:string" use="optional" default="[{ name: 'clipboard', items : [ 'Cut','Copy','Paste','PasteText','PasteFromWord','-','Undo','Redo' ] }, '/', { name: 'basicstyles', items : [ 'Bold','Italic','Underline' ] },{ name: 'paragraph', items : [ 'NumberedList','BulletedList' ] }]" />
+									<xs:attribute name="overwriteStandardToolBar" type="xs:string" use="optional" default="[{ name: 'clipboard', items : [ 'Cut','Copy','Paste','PasteText','PasteFromWord','-','Undo','Redo' ] }, { name: 'links', items : [ 'Link','Unlink','Anchor' ] }, { name: 'insert', items : [ 'Image','Table','HorizontalRule','SpecialChar' ] },{ name: 'tools', items : [ 'Maximize'] }, { name: 'document', items : [ 'Source'] }, '/', { name: 'basicstyles', items : [ 'Bold','Italic','Underline','Strike','Subscript','Superscript','-','RemoveFormat' ] }, { name: 'paragraph', items : [ 'NumberedList','BulletedList','-','Outdent','Indent','-','Blockquote' ] },{ name: 'styles', items : [ 'Styles','Format' ] }]" />
+									<xs:attribute name="contentsCssPath" type="xs:string" use="optional" default="~/N2/Resources/ckeditor/contents.css" />
 									<xs:attribute name="advancedMenus" type="xs:boolean" use="optional" default="false" />
 									<xs:attribute name="allowedContent" type="xs:boolean" use="optional" />
-                  <xs:attribute name="overwriteLanguage" type="xs:string" use="optional" default="en" />
+									<xs:attribute name="overwriteLanguage" type="xs:string" use="optional" default="en" />
 								</xs:complexType>
 							</xs:element>
 							<xs:element name="nameEditor" minOccurs="0">
@@ -661,8 +661,8 @@
 									<xs:attribute name="whitespaceReplacement" type="xs:string" use="optional" />
 									<xs:attribute name="toLower" type="xs:boolean" use="optional" />
 									<xs:attribute name="showKeepUpdated" type="xs:boolean" use="optional" />
-                  <xs:attribute name="keepUpdatedDefaultValue" type="xs:boolean" use="optional" />
-                  <xs:attribute name="maxUrlLength" type="xs:int" use="optional" />
+									<xs:attribute name="keepUpdatedDefaultValue" type="xs:boolean" use="optional" />
+									<xs:attribute name="maxUrlLength" type="xs:int" use="optional" />
 								</xs:complexType>
 							</xs:element>
 							<xs:element name="defaultDirectory" minOccurs="0">
@@ -704,22 +704,22 @@
 							</xs:element>
 							<xs:element name="docviewer" minOccurs="0">
 								<xs:complexType>
-										<xs:sequence>
-											<xs:element name="clear" minOccurs="0" maxOccurs="1"/>
-											<xs:element name="remove" minOccurs="0" maxOccurs="unbounded">
-												<xs:complexType>
-													<xs:attribute name="extensions" type="xs:string" use="required"/>
-												</xs:complexType>
-											</xs:element>
-											<xs:element name="add" minOccurs="0" maxOccurs="unbounded">
-												<xs:complexType>
-													<xs:attribute name="extensions" type="xs:string" use="required" />
-													<xs:attribute name="enabled" type="xs:boolean" use="optional" />
-													<xs:attribute name="url" type="xs:string" use="optional" />
-													<xs:attribute name="maxsize" type="xs:string" use="optional" />
-												</xs:complexType>
-											</xs:element>
-										</xs:sequence>
+									<xs:sequence>
+										<xs:element name="clear" minOccurs="0" maxOccurs="1"/>
+										<xs:element name="remove" minOccurs="0" maxOccurs="unbounded">
+											<xs:complexType>
+												<xs:attribute name="extensions" type="xs:string" use="required"/>
+											</xs:complexType>
+										</xs:element>
+										<xs:element name="add" minOccurs="0" maxOccurs="unbounded">
+											<xs:complexType>
+												<xs:attribute name="extensions" type="xs:string" use="required" />
+												<xs:attribute name="enabled" type="xs:boolean" use="optional" />
+												<xs:attribute name="url" type="xs:string" use="optional" />
+												<xs:attribute name="maxsize" type="xs:string" use="optional" />
+											</xs:complexType>
+										</xs:element>
+									</xs:sequence>
 								</xs:complexType>
 							</xs:element>
 							<xs:element name="images" minOccurs="0">
@@ -762,7 +762,7 @@
 									</xs:all>
 									<xs:attribute name="resizedExtensions" type="xs:string" use="optional" default=".jpg,.jpeg" />
 									<xs:attribute name="resizeUploadedImages" type="xs:boolean" use="optional" default="true" />
-                  <xs:attribute name="resizeSeparator" type="xs:string" use="optional" default="_" />
+									<xs:attribute name="resizeSeparator" type="xs:string" use="optional" default="_" />
 								</xs:complexType>
 							</xs:element>
 							<xs:element name="membership" minOccurs="0">
@@ -786,7 +786,7 @@
 									<xs:attribute name="editInterfaceUrl" type="xs:string" use="optional" />
 									<xs:attribute name="newItemUrl" type="xs:string" use="optional" />
 									<xs:attribute name="deleteItemUrl" type="xs:string" use="optional" />
-                  <xs:attribute name="ensureLocalhostPreviewUrls" type="xs:boolean" use="optional" />
+									<xs:attribute name="ensureLocalhostPreviewUrls" type="xs:boolean" use="optional" />
 								</xs:complexType>
 							</xs:element>
 							<xs:element name="collaboration" minOccurs="0">
@@ -811,6 +811,49 @@
 							<xs:element name="organize" minOccurs="0">
 								<xs:complexType>
 									<xs:attribute name="useLegacyControlPanel" type="xs:boolean" use="optional" />
+								</xs:complexType>
+							</xs:element>
+							<xs:element name="commandButtons" minOccurs="0">
+								<xs:complexType>
+									<xs:all>
+										<xs:element name="saveButton" minOccurs="0" maxOccurs="1">
+											<xs:complexType>
+												<xs:attribute name="enabled" type="xs:boolean" use="optional" default="true" />
+												<xs:attribute name="text" type="xs:string" use="optional" />
+												<xs:attribute name="tooltip" type="xs:string" use="optional" />
+											</xs:complexType>
+										</xs:element>
+										<xs:element name="saveAndPreviewButton" minOccurs="0" maxOccurs="1">
+											<xs:complexType>
+												<xs:attribute name="enabled" type="xs:boolean" use="optional" default="true" />
+												<xs:attribute name="text" type="xs:string" use="optional" />
+												<xs:attribute name="tooltip" type="xs:string" use="optional" />
+											</xs:complexType>
+										</xs:element>
+										<xs:element name="saveVersionInFutureButton" minOccurs="0" maxOccurs="1">
+											<xs:complexType>
+												<xs:attribute name="enabled" type="xs:boolean" use="optional" default="true" />
+												<xs:attribute name="text" type="xs:string" use="optional" />
+												<xs:attribute name="tooltip" type="xs:string" use="optional" />
+											</xs:complexType>
+										</xs:element>
+										<xs:element name="unpublishButton" minOccurs="0" maxOccurs="1">
+											<xs:complexType>
+												<xs:attribute name="enabled" type="xs:boolean" use="optional" default="true" />
+												<xs:attribute name="text" type="xs:string" use="optional" />
+												<xs:attribute name="tooltip" type="xs:string" use="optional" />
+											</xs:complexType>
+										</xs:element>
+										<xs:element name="publishButton" minOccurs="0" maxOccurs="1">
+											<xs:complexType>
+												<xs:attribute name="enabled" type="xs:boolean" use="optional" default="true" />
+												<xs:attribute name="text" type="xs:string" use="optional" />
+												<xs:attribute name="tooltip" type="xs:string" use="optional" />
+											</xs:complexType>
+										</xs:element>
+									</xs:all>
+									<xs:attribute name="keepPublishedDateOnSave" type="xs:boolean" use="optional" default="false" />
+									<xs:attribute name="enableFutureSchedulingOnPublish" type="xs:boolean" use="optional" default="false" />
 								</xs:complexType>
 							</xs:element>
 						</xs:all>

--- a/src/Framework/N2/Configuration/CommandButtonElement.cs
+++ b/src/Framework/N2/Configuration/CommandButtonElement.cs
@@ -1,0 +1,29 @@
+﻿using System.Configuration;
+
+namespace N2.Configuration
+{
+	public class CommandButtonElement : ConfigurationElement
+	{
+		[ConfigurationProperty("enabled", IsRequired = false, DefaultValue = true)]
+		public bool Enabled
+		{
+			get { return (bool)base["enabled"]; }
+			set { base["enabled"] = value; }
+		}
+
+		[ConfigurationProperty("text", IsRequired = false)]
+		public string Text
+		{
+			get { return (string)base["text"]; }
+			set { base["text"] = value; }
+		}
+
+		[ConfigurationProperty("tooltip", IsRequired = false)]
+		public string ToolTip
+		{
+			get { return (string)base["tooltip"]; }
+			set { base["tooltip"] = value; }
+		}
+
+	}
+}

--- a/src/Framework/N2/Configuration/CommandButtonGroupElement.cs
+++ b/src/Framework/N2/Configuration/CommandButtonGroupElement.cs
@@ -1,0 +1,56 @@
+﻿using System.Configuration;
+
+namespace N2.Configuration
+{
+	public class CommandButtonGroupElement : ConfigurationElement
+	{
+		[ConfigurationProperty("saveButton", IsRequired = false)]
+		public CommandButtonElement SaveButton
+		{
+			get { return (CommandButtonElement)base["saveButton"]; }
+			set { base["saveButton"] = value; }
+		}
+
+		[ConfigurationProperty("saveAndPreviewButton", IsRequired = false)]
+		public CommandButtonElement SaveAndPreviewButton
+		{
+			get { return (CommandButtonElement)base["saveAndPreviewButton"]; }
+			set { base["saveAndPreviewButton"] = value; }
+		}
+
+		[ConfigurationProperty("saveVersionInFutureButton", IsRequired = false)]
+		public CommandButtonElement SaveVersionInFutureButton
+		{
+			get { return (CommandButtonElement)base["saveVersionInFutureButton"]; }
+			set { base["saveVersionInFutureButton"] = value; }
+		}
+
+		[ConfigurationProperty("unpublishButton", IsRequired = false)]
+		public CommandButtonElement UnpublishButton
+		{
+			get { return (CommandButtonElement)base["unpublishButton"]; }
+			set { base["unpublishButton"] = value; }
+		}
+
+		[ConfigurationProperty("publishButton", IsRequired = false)]
+		public CommandButtonElement PublishButton
+		{
+			get { return (CommandButtonElement)base["publishButton"]; }
+			set { base["publishButton"] = value; }
+		}
+
+		[ConfigurationProperty("enableFutureSchedulingOnPublish", IsRequired = false, DefaultValue = false)]
+		public bool EnableFutureSchedulingOnPublish
+		{
+			get { return (bool)base["enableFutureSchedulingOnPublish"]; }
+			set { base["enableFutureSchedulingOnPublish"] = value; }
+		}
+
+		[ConfigurationProperty("keepPublishedDateOnSave", IsRequired = false, DefaultValue = false)]
+		public bool KeepPublishedDateOnSave
+		{
+			get { return (bool)base["keepPublishedDateOnSave"]; }
+			set { base["keepPublishedDateOnSave"] = value; }
+		}
+	}
+}

--- a/src/Framework/N2/Configuration/EditSection.cs
+++ b/src/Framework/N2/Configuration/EditSection.cs
@@ -186,5 +186,14 @@ namespace N2.Configuration
             get { return (AutosaveElement)base["autosave"]; }
             set { base["autosave"] = value; }
         }
+
+        /// <summary>Configuration about edit page command buttons.</summary>
+        [ConfigurationProperty("commandButtons")]
+        public CommandButtonGroupElement CommandButtons
+        {
+            get { return (CommandButtonGroupElement)base["commandButtons"]; }
+            set { base["commandButtons"] = value; }
+        }
+
     }
 }

--- a/src/Framework/N2/Edit/Workflow/CommandFactory.cs
+++ b/src/Framework/N2/Edit/Workflow/CommandFactory.cs
@@ -156,7 +156,7 @@ namespace N2.Edit.Workflow
                     if (context.Content.State == ContentState.Published || context.Content.State == ContentState.Unpublished)
                         return Compose("Save changes", Authorize(Permission.Write), validate, useNewVersion, updateObject, draftState, updateDate, saveOnPageVersion);
                     else
-                        return Compose("Save changes", Authorize(Permission.Write), validate, updateObject, draftState, updateDate, save);
+                        return Compose("Save changes", Authorize(Permission.Write), validate, updateObject, unpublishedState, updateDate, save);
                 }
                 else if (context.Content.State == ContentState.Published || context.Content.State == ContentState.Unpublished)
                     // version of another item

--- a/src/Framework/N2/Edit/Workflow/Commands/UpdateContentStateSchedulePublishCommand.cs
+++ b/src/Framework/N2/Edit/Workflow/Commands/UpdateContentStateSchedulePublishCommand.cs
@@ -1,0 +1,28 @@
+using System.Linq;
+namespace N2.Edit.Workflow.Commands
+{
+    public class UpdateContentStateSchedulePublishCommand : CommandBase<CommandContext>
+    {
+        StateChanger changer;
+
+        public UpdateContentStateSchedulePublishCommand(StateChanger changer)
+        {
+            this.changer = changer;
+        }
+
+        public override void Process(CommandContext state)
+        {
+            // items with a future publish date should have a 'waiting' state
+            var toState = state.Content.Published.HasValue && state.Content.Published > N2.Utility.CurrentTime() ? ContentState.Waiting : ContentState.Published;
+
+            changer.ChangeTo(state.Content, toState);
+            foreach (ContentItem item in state.GetItemsToSave().Distinct())
+            {
+                if (item == state.Content)
+                    continue;
+
+                changer.ChangeTo(item, toState);
+            }
+        }
+    }
+}

--- a/src/Framework/N2/N2.csproj
+++ b/src/Framework/N2/N2.csproj
@@ -152,9 +152,11 @@
     <Compile Include="Configuration\CkEditorElement.cs" />
     <Compile Include="Configuration\ClientElement.cs" />
     <Compile Include="Configuration\CollaborationElement.cs" />
+    <Compile Include="Configuration\CommandButtonElement.cs" />
     <Compile Include="Configuration\FileListElement.cs" />
     <Compile Include="Configuration\DocViewerElement.cs" />
     <Compile Include="Configuration\HtmlSanitizeElement.cs" />
+    <Compile Include="Configuration\CommandButtonGroupElement.cs" />
     <Compile Include="Configuration\OrganizeElement.cs" />
     <Compile Include="Configuration\OutputCacheInvalidationMode.cs" />
     <Compile Include="Configuration\RavenElement.cs" />
@@ -195,6 +197,7 @@
     <Compile Include="Edit\Collaboration\TraceReaderMessageProvider.cs" />
     <Compile Include="Edit\Versioning\InvalidVersionInfo.cs" />
     <Compile Include="Edit\Versioning\VersionInfo.cs" />
+    <Compile Include="Edit\Workflow\Commands\UpdateContentStateSchedulePublishCommand.cs" />
     <Compile Include="Engine\Accessor.cs" />
     <Compile Include="Engine\Globalization\ContentTranslator.cs" />
     <Compile Include="Engine\Globalization\ITranslator.cs" />

--- a/src/Mvc/MvcTemplates/N2/Content/Edit.aspx.cs
+++ b/src/Mvc/MvcTemplates/N2/Content/Edit.aspx.cs
@@ -95,11 +95,63 @@ namespace N2.Edit
 			bool isWritableByUser = Security.IsAuthorized(User, Selection.SelectedItem, Permission.Write);
 			bool isExisting = ie.CurrentItem.ID != 0;
 
-			btnSavePublish.Visible = isPublicableItem && isPublicableByUser;
-			btnPreview.Visible = isVersionable && isWritableByUser;
-			btnSaveUnpublished.Visible = isVersionable && isWritableByUser;
-			hlFuturePublish.Visible = isVersionable && isPublicableByUser;
-			btnUnpublish.Visible = isVersionable && isPublicableByUser;
+			var config = new ConfigurationManagerWrapper();
+
+			//save and publish
+			btnSavePublish.Visible = config.Sections.Management.CommandButtons.PublishButton.Enabled && isPublicableItem && isPublicableByUser;
+			if (btnSavePublish.Visible)
+            {
+				if (string.IsNullOrWhiteSpace(config.Sections.Management.CommandButtons.PublishButton.Text) == false)
+					btnSavePublish.Text = config.Sections.Management.CommandButtons.PublishButton.Text;
+
+				if (string.IsNullOrWhiteSpace(config.Sections.Management.CommandButtons.PublishButton.ToolTip) == false)
+					btnSavePublish.ToolTip = config.Sections.Management.CommandButtons.PublishButton.ToolTip;
+			}
+
+			//save and preview
+			btnPreview.Visible = config.Sections.Management.CommandButtons.SaveAndPreviewButton.Enabled && isVersionable && isWritableByUser;
+			if (btnPreview.Visible)
+			{
+				if (string.IsNullOrWhiteSpace(config.Sections.Management.CommandButtons.SaveAndPreviewButton.Text) == false)
+					btnPreview.Text = config.Sections.Management.CommandButtons.SaveAndPreviewButton.Text;
+
+				if (string.IsNullOrWhiteSpace(config.Sections.Management.CommandButtons.SaveAndPreviewButton.ToolTip) == false)
+					btnPreview.ToolTip = config.Sections.Management.CommandButtons.SaveAndPreviewButton.ToolTip;
+			}
+
+			//save
+			btnSaveUnpublished.Visible = config.Sections.Management.CommandButtons.SaveButton.Enabled && isVersionable && isWritableByUser;
+			if (btnSaveUnpublished.Visible)
+			{
+				if (string.IsNullOrWhiteSpace(config.Sections.Management.CommandButtons.SaveButton.Text) == false)
+					btnSaveUnpublished.Text = config.Sections.Management.CommandButtons.SaveButton.Text;
+
+				if (string.IsNullOrWhiteSpace(config.Sections.Management.CommandButtons.SaveButton.ToolTip) == false)
+					btnSaveUnpublished.ToolTip = config.Sections.Management.CommandButtons.SaveButton.ToolTip;
+			}
+
+			//save version in future
+			hlFuturePublish.Visible = config.Sections.Management.CommandButtons.SaveVersionInFutureButton.Enabled && isVersionable && isPublicableByUser;
+			if (hlFuturePublish.Visible)
+			{
+				if (string.IsNullOrWhiteSpace(config.Sections.Management.CommandButtons.SaveVersionInFutureButton.Text) == false)
+					hlFuturePublish.Text = config.Sections.Management.CommandButtons.SaveVersionInFutureButton.Text;
+
+				if (string.IsNullOrWhiteSpace(config.Sections.Management.CommandButtons.SaveVersionInFutureButton.ToolTip) == false)
+					hlFuturePublish.ToolTip = config.Sections.Management.CommandButtons.SaveVersionInFutureButton.ToolTip;
+			}
+
+			//unpublish
+			btnUnpublish.Visible = config.Sections.Management.CommandButtons.UnpublishButton.Enabled && isVersionable && isPublicableByUser;
+			if (btnUnpublish.Visible)
+			{
+				if (string.IsNullOrWhiteSpace(config.Sections.Management.CommandButtons.UnpublishButton.Text) == false)
+					btnUnpublish.Text = config.Sections.Management.CommandButtons.UnpublishButton.Text;
+
+				if (string.IsNullOrWhiteSpace(config.Sections.Management.CommandButtons.UnpublishButton.ToolTip) == false)
+					btnUnpublish.ToolTip = config.Sections.Management.CommandButtons.UnpublishButton.ToolTip;
+			}
+
 		}
 
 		protected override void OnLoad(EventArgs e)
@@ -135,8 +187,8 @@ namespace N2.Edit
 			var ctx = ie.CreateCommandContext();
 
             try
-            {
-                Commands.Publish(ctx);
+			{
+				Commands.Publish(ctx);
 
                 Engine.AddActivity(new ManagementActivity { Operation = "Publish", PerformedBy = User.Identity.Name, Path = ie.CurrentItem.Path, ID = ie.CurrentItem.ID });
 
@@ -162,8 +214,8 @@ namespace N2.Edit
 			var ctx = ie.CreateCommandContext();
 
             try
-            {
-                if (ctx.Content.VersionOf.HasValue)
+			{
+				if (ctx.Content.VersionOf.HasValue)
                 {
                     var draftOfTopEditor = ctx.Content.FindPartVersion(CurrentItem);
                     ie.UpdateObject(new CommandContext(ie.Definition, draftOfTopEditor, Interfaces.Editing, Context.User));
@@ -186,16 +238,7 @@ namespace N2.Edit
                     previewUrl = previewUrl.SetQueryParameter(PathData.VersionIndexQueryKey, item.VersionIndex);
                 }
 
-                //Items that have no versions (first version) and are drafts, will be updated to unpublished state
-                //  in order for Save and Preview to be able to work cross sites
-                if (!ctx.Content.VersionOf.HasValue && ctx.Content.VersionIndex == 0)
-                {
-                    var item = ie.CurrentItem;
-                    item.State = ContentState.Unpublished;
-                    Engine.Persister.Save(item);
-                }
-
-                previewUrl = previewUrl.SetQueryParameter("Preview", "true");
+				previewUrl = previewUrl.SetQueryParameter("Preview", "true");
 
                 Engine.AddActivity(new ManagementActivity { Operation = "Preview", PerformedBy = User.Identity.Name, Path = ie.CurrentItem.Path, ID = ie.CurrentItem.ID });
 
@@ -211,8 +254,8 @@ namespace N2.Edit
         {
             var ctx = ie.CreateCommandContext();
             try
-            {
-                if (ctx.Content.VersionOf.HasValue)
+			{
+				if (ctx.Content.VersionOf.HasValue)
                 {
                     var draftOfTopEditor = ctx.Content.FindPartVersion(CurrentItem);
                     ie.UpdateObject(new CommandContext(ie.Definition, draftOfTopEditor, Interfaces.Editing, Context.User));
@@ -222,15 +265,6 @@ namespace N2.Edit
                 else
                 {
                     Commands.Save(ctx);
-                }
-
-                //Items that have no versions (first version) and are drafts, will be updated to unpublished state
-                //  so that when saving and viewing the item, it will work cross sites
-                if (!ctx.Content.VersionOf.HasValue && ctx.Content.VersionIndex == 0)
-                {
-                    var item = ie.CurrentItem;
-                    item.State = ContentState.Unpublished;
-                    Engine.Persister.Save(item);
                 }
 
 				Url redirectTo = ManagementPaths.GetEditExistingItemUrl(ctx.Content);


### PR DESCRIPTION
Configuration options added to command buttons on the edit screen.
- Enable/disable each button.
- Text and tooltip configuration for each button.
- Publish button to look for the enableFutureSchedulingOnPublish configuration to check for future date and save state as waiting.
- Save as Draft button to save original version as unpublished. This was already there but inside the Edit.aspx.cs but moved to the button command itself to avoid double save.