### PR TITLE
IContentVersionRepository for separate dependency injection

### DIFF
--- a/src/Framework/Management.Tests/Trash/TrashDeleteRelationsTests.cs
+++ b/src/Framework/Management.Tests/Trash/TrashDeleteRelationsTests.cs
@@ -192,7 +192,7 @@ namespace N2.Management.Tests.Trash
 
             persister.Dispose();
             item2 = persister.Get<ThrowableItem>(item2.ID);
-			var repository = engine.Resolve<ContentVersionRepository>();
+			var repository = engine.Resolve<IContentVersionRepository>();
 			version = repository.DeserializeVersion(repository.GetVersion(item2, version.VersionIndex)); 
             // persister.Get<ThrowableItem>(version.ID);
             

--- a/src/Framework/N2/Details/EditableMultiUploadButtonAttribute.cs
+++ b/src/Framework/N2/Details/EditableMultiUploadButtonAttribute.cs
@@ -94,7 +94,7 @@ namespace N2.Details
                 
                 if (path.CurrentPage.VersionOf.HasValue)
                 { 
-					var cvr = Engine.Resolve<ContentVersionRepository>();
+					var cvr = Engine.Resolve<IContentVersionRepository>();
 					cvr.Save(path.CurrentPage);
                 }
                 else
@@ -154,7 +154,7 @@ namespace N2.Details
 			if (page.ID == 0 || (!page.VersionOf.HasValue && (page.State == ContentState.New || page.State == ContentState.Draft)))
                 return new PathData(page, item);
 
-            var cvr = Engine.Resolve<ContentVersionRepository>();
+            var cvr = Engine.Resolve<IContentVersionRepository>();
             var vm = Engine.Resolve<IVersionManager>();
             var path = PartsExtensions.EnsureDraft(vm, cvr, "", item.GetVersionKey(), item);
 

--- a/src/Framework/N2/Edit/Api/ContentHandler.cs
+++ b/src/Framework/N2/Edit/Api/ContentHandler.cs
@@ -216,7 +216,7 @@ namespace N2.Management.Api
 			var persister = engine.Persister;
 			var integrity = engine.IntegrityManager;
 			var versions = engine.Resolve<IVersionManager>();
-			var versionRepository = engine.Resolve<ContentVersionRepository>();
+			var versionRepository = engine.Resolve<IContentVersionRepository>();
 
 			string versionIndex = selection.RequestValueAccessor(PathData.VersionIndexQueryKey);
 			string versionKey = selection.RequestValueAccessor(PathData.VersionKeyQueryKey);

--- a/src/Framework/N2/Edit/SelectionUtility.cs
+++ b/src/Framework/N2/Edit/SelectionUtility.cs
@@ -133,7 +133,7 @@ namespace N2.Edit
             if (dr.HasDraft(selectedItem))
             {
                 var draft = dr.GetDraftInfo(selectedItem);
-                var cvr = Engine.Resolve<ContentVersionRepository>();
+                var cvr = Engine.Resolve<IContentVersionRepository>();
                 selectedItem = cvr.ParseVersion(draft.VersionIndex.ToString(), RequestValueAccessor(PathData.VersionKeyQueryKey), selectedItem);
             }
             return selectedItem;
@@ -141,7 +141,7 @@ namespace N2.Edit
 
         private ContentItem ParseSpecificVersion(ContentItem selectedItem)
         {
-            var cvr = Engine.Resolve<ContentVersionRepository>();
+            var cvr = Engine.Resolve<IContentVersionRepository>();
             selectedItem = cvr.ParseVersion(RequestValueAccessor(PathData.VersionIndexQueryKey), RequestValueAccessor(PathData.VersionKeyQueryKey), selectedItem);
             return selectedItem;
         }

--- a/src/Framework/N2/Edit/Versioning/ContentVersionCleanup.cs
+++ b/src/Framework/N2/Edit/Versioning/ContentVersionCleanup.cs
@@ -13,9 +13,9 @@ namespace N2.Edit.Versioning
     public class ContentVersionCleanup : IAutoStart
     {
         private IItemNotifier notifier;
-        private ContentVersionRepository repository;
+        private IContentVersionRepository repository;
 
-        public ContentVersionCleanup(IItemNotifier notifier, ContentVersionRepository repository)
+        public ContentVersionCleanup(IItemNotifier notifier, IContentVersionRepository repository)
         {
             this.notifier = notifier;
             this.repository = repository;

--- a/src/Framework/N2/Edit/Versioning/ContentVersionRepository.cs
+++ b/src/Framework/N2/Edit/Versioning/ContentVersionRepository.cs
@@ -1,19 +1,16 @@
-using System;
-using System.Collections.Generic;
-using System.IO;
-using System.Linq;
-using System.Text;
 using N2.Engine;
+using N2.Persistence;
+using N2.Persistence.Proxying;
 using N2.Persistence.Serialization;
 using N2.Web;
-using N2.Persistence;
-using System.Security.Principal;
-using N2.Persistence.Proxying;
+using System;
+using System.Collections.Generic;
+using System.Linq;
 
 namespace N2.Edit.Versioning
 {
     [Service]
-    public class ContentVersionRepository
+    public class ContentVersionRepository : IContentVersionRepository
     {
         public IRepository<ContentVersion> Repository { get; private set; }
         public event EventHandler<VersionsChangedEventArgs> VersionsChanged;

--- a/src/Framework/N2/Edit/Versioning/ContentVersionRepository.cs
+++ b/src/Framework/N2/Edit/Versioning/ContentVersionRepository.cs
@@ -9,7 +9,7 @@ using System.Linq;
 
 namespace N2.Edit.Versioning
 {
-    [Service]
+    [Service(typeof(IContentVersionRepository))]
     public class ContentVersionRepository : IContentVersionRepository
     {
         public IRepository<ContentVersion> Repository { get; private set; }

--- a/src/Framework/N2/Edit/Versioning/DraftRepository.cs
+++ b/src/Framework/N2/Edit/Versioning/DraftRepository.cs
@@ -20,10 +20,10 @@ namespace N2.Edit.Versioning
     [Service]
     public class DraftRepository : IAutoStart
     {
-        public ContentVersionRepository Versions { get; private set; }
+        public IContentVersionRepository Versions { get; private set; }
         private CacheWrapper cache;
 
-        public DraftRepository(ContentVersionRepository repository, CacheWrapper cache)
+        public DraftRepository(IContentVersionRepository repository, CacheWrapper cache)
         {
             this.Versions = repository;
             this.cache = cache;

--- a/src/Framework/N2/Edit/Versioning/IContentVersionRepository.cs
+++ b/src/Framework/N2/Edit/Versioning/IContentVersionRepository.cs
@@ -1,0 +1,37 @@
+using N2.Persistence;
+using System;
+using System.Collections.Generic;
+
+namespace N2.Edit.Versioning
+{
+    public interface IContentVersionRepository
+	{
+		IRepository<ContentVersion> Repository { get; }
+		event EventHandler<VersionsChangedEventArgs> VersionsChanged;
+		event EventHandler<ItemEventArgs> VersionsDeleted;
+		
+		ContentVersion GetVersion(ContentItem item, int versionIndex = -1);
+
+        IEnumerable<ContentVersion> GetVersions(ContentItem item);
+
+		ContentItem GetLatestVersion(ContentItem item);
+
+		int GetGreatestVersionIndex(ContentItem item);
+
+		IEnumerable<ContentVersion> GetVersionsScheduledForPublish(DateTime publishVersionsScheduledBefore);
+
+		ContentVersion Save(ContentItem item, bool asPreviousVersion = true);
+
+		void Delete(ContentItem item);
+
+		void DeleteVersionsOf(ContentItem item);
+
+		string Serialize(ContentItem item);
+
+		ContentItem Deserialize(string xml);
+
+		ContentItem DeserializeVersion(ContentVersion version);
+
+		void SerializeVersion(ContentVersion version, ContentItem item);
+    }
+}

--- a/src/Framework/N2/Edit/Versioning/VersionManager.cs
+++ b/src/Framework/N2/Edit/Versioning/VersionManager.cs
@@ -21,12 +21,12 @@ namespace N2.Edit.Versioning
     [Service(typeof(IVersionManager))]
     public class VersionManager : IVersionManager
     {
-        public ContentVersionRepository Repository { get; private set; }
+        public IContentVersionRepository Repository { get; private set; }
         readonly IContentItemRepository itemRepository;
         readonly StateChanger stateChanger;
         int maximumVersionsPerItem = 100;
 
-        public VersionManager(ContentVersionRepository versionRepository, IContentItemRepository itemRepository, StateChanger stateChanger, EditSection config)
+        public VersionManager(IContentVersionRepository versionRepository, IContentItemRepository itemRepository, StateChanger stateChanger, EditSection config)
         {
             this.Repository = versionRepository;
             this.itemRepository = itemRepository;

--- a/src/Framework/N2/Edit/Versioning/VersioningExtensions.cs
+++ b/src/Framework/N2/Edit/Versioning/VersioningExtensions.cs
@@ -187,13 +187,13 @@ namespace N2.Edit.Versioning
             return previewedItem;
         }
 
-        public static ContentItem GetVersionItem(this ContentVersionRepository repository, ContentItem item, int versionIndex)
+        public static ContentItem GetVersionItem(this IContentVersionRepository repository, ContentItem item, int versionIndex)
 		{
 			var version = repository.GetVersion(item, versionIndex);
 			return repository.DeserializeVersion(version);
 		}
 
-	    public static VersionInfo GetVersionInfo(this ContentVersion version, ContentVersionRepository repository)
+	    public static VersionInfo GetVersionInfo(this ContentVersion version, IContentVersionRepository repository)
 	    {
 		    try
 		    {

--- a/src/Framework/N2/Engine/MediumTrust/StaticDefaultServiceContainerConfigurer.cs
+++ b/src/Framework/N2/Engine/MediumTrust/StaticDefaultServiceContainerConfigurer.cs
@@ -51,6 +51,7 @@ namespace N2.Engine.Configuration
             engine.Container.AddComponent("n2.repository.nh", typeof(INHRepository<>), typeof(NHRepository<>));
 #pragma warning restore 612, 618
             engine.Container.AddComponent("n2.versioning", typeof(IVersionManager), typeof(VersionManager));
+            engine.Container.AddComponent("n2.versioningRepository", typeof(IContentVersionRepository), typeof(ContentVersionRepository));
             engine.Container.AddComponent("n2.persister", typeof(IPersister), typeof(ContentPersister));
             engine.Container.AddComponent("n2.itemFinder", typeof(IItemFinder), typeof(ItemFinder));
             //trail tracker

--- a/src/Framework/N2/N2.csproj
+++ b/src/Framework/N2/N2.csproj
@@ -195,6 +195,7 @@
     <Compile Include="Edit\Collaboration\MessageSourceBase.cs" />
     <Compile Include="Edit\Collaboration\SourceInfo.cs" />
     <Compile Include="Edit\Collaboration\TraceReaderMessageProvider.cs" />
+    <Compile Include="Edit\Versioning\IContentVersionRepository.cs" />
     <Compile Include="Edit\Versioning\InvalidVersionInfo.cs" />
     <Compile Include="Edit\Versioning\VersionInfo.cs" />
     <Compile Include="Edit\Workflow\Commands\UpdateContentStateSchedulePublishCommand.cs" />

--- a/src/Framework/N2/Persistence/Sources/DatabaseSource.cs
+++ b/src/Framework/N2/Persistence/Sources/DatabaseSource.cs
@@ -118,7 +118,7 @@ namespace N2.Persistence.Sources
 
         public override void Delete(ContentItem item)
         {
-            var versionRepository = Engine.Resolve<ContentVersionRepository>();
+            var versionRepository = Engine.Resolve<IContentVersionRepository>();
             using (var tx = repository.BeginTransaction())
             {
                 try
@@ -138,7 +138,7 @@ namespace N2.Persistence.Sources
             }
         }
 
-        private void DeleteRecursive(ContentItem itemToDelete, ContentVersionRepository versionRepository)
+        private void DeleteRecursive(ContentItem itemToDelete, IContentVersionRepository versionRepository)
         {
             using (logger.Indent())
             {

--- a/src/Framework/N2/Persistence/Sources/VersionSource.cs
+++ b/src/Framework/N2/Persistence/Sources/VersionSource.cs
@@ -11,16 +11,16 @@ namespace N2.Persistence.Sources
     [ContentSource]
     public class VersionSource : SourceBase<IActiveContent>
     {
-        private ContentVersionRepository repository;
+        private IContentVersionRepository repository;
 
         public VersionSource(IEngine engine)
         {
             this.Engine = engine;
         }
 
-        public ContentVersionRepository Repository
+        public IContentVersionRepository Repository
         {
-            get { return repository ?? (repository = Engine.Resolve<ContentVersionRepository>()); }
+            get { return repository ?? (repository = Engine.Resolve<IContentVersionRepository>()); }
             set { repository = value; }
         }
 

--- a/src/Framework/N2/Web/Parts/CreateUrlProvider.cs
+++ b/src/Framework/N2/Web/Parts/CreateUrlProvider.cs
@@ -18,9 +18,9 @@ namespace N2.Web.Parts
         readonly ITemplateAggregator templates;
         readonly Navigator navigator;
         private IVersionManager versions;
-        private ContentVersionRepository versionRepository;
+        private IContentVersionRepository versionRepository;
 
-        public CreateUrlProvider(IPersister persister, IEditUrlManager editUrlManager, IDefinitionManager definitions, ITemplateAggregator templates, ContentActivator activator, Navigator navigator, IVersionManager versions, ContentVersionRepository versionRepository)
+        public CreateUrlProvider(IPersister persister, IEditUrlManager editUrlManager, IDefinitionManager definitions, ITemplateAggregator templates, ContentActivator activator, Navigator navigator, IVersionManager versions, IContentVersionRepository versionRepository)
         {
             this.persister = persister;
             this.managementPaths = editUrlManager;

--- a/src/Framework/N2/Web/Parts/ItemCopyer.cs
+++ b/src/Framework/N2/Web/Parts/ItemCopyer.cs
@@ -15,9 +15,9 @@ namespace N2.Web.Parts
         readonly IPersister persister;
         readonly Integrity.IIntegrityManager integrity;
         readonly IVersionManager versions;
-        readonly ContentVersionRepository versionRepository;
+        readonly IContentVersionRepository versionRepository;
 
-        public ItemCopyer(IPersister persister, Navigator navigator, Integrity.IIntegrityManager integrity, IVersionManager versions, ContentVersionRepository versionRepository)
+        public ItemCopyer(IPersister persister, Navigator navigator, Integrity.IIntegrityManager integrity, IVersionManager versions, IContentVersionRepository versionRepository)
         {
             this.persister = persister;
             this.navigator = navigator;

--- a/src/Framework/N2/Web/Parts/ItemMover.cs
+++ b/src/Framework/N2/Web/Parts/ItemMover.cs
@@ -15,9 +15,9 @@ namespace N2.Web.Parts
         private readonly IPersister persister;
         readonly IIntegrityManager integrity;
         readonly IVersionManager versions;
-        readonly ContentVersionRepository versionRepository;
+        readonly IContentVersionRepository versionRepository;
 
-        public ItemMover(IPersister persister, Navigator navigator, IIntegrityManager integrity, IVersionManager versions, ContentVersionRepository versionRepository)
+        public ItemMover(IPersister persister, Navigator navigator, IIntegrityManager integrity, IVersionManager versions, IContentVersionRepository versionRepository)
         {
             this.persister = persister;
             this.navigator = navigator;

--- a/src/Framework/N2/Web/Parts/PartsAdapter.cs
+++ b/src/Framework/N2/Web/Parts/PartsAdapter.cs
@@ -35,7 +35,7 @@ namespace N2.Web.Parts
         IDefinitionManager definitions;
         IEnumerable<ITemplateProvider> templates;
         ISecurityManager security;
-        ContentVersionRepository versionRepository;
+        IContentVersionRepository versionRepository;
         Rendering.ContentRendererSelector rendererSelector;
         private ITemplateAggregator templateAggregator;
 
@@ -47,9 +47,9 @@ namespace N2.Web.Parts
             set { rendererSelector = value; }
         }
 
-        public ContentVersionRepository VersionRepository
+        public IContentVersionRepository VersionRepository
         {
-            get { return versionRepository ?? Engine.Resolve<ContentVersionRepository>(); }
+            get { return versionRepository ?? Engine.Resolve<IContentVersionRepository>(); }
             set { versionRepository = value; }
         }
 

--- a/src/Framework/N2/Web/Parts/PartsExtensions.cs
+++ b/src/Framework/N2/Web/Parts/PartsExtensions.cs
@@ -150,18 +150,18 @@ namespace N2.Web.Parts
             }
         }
 
-		public static PathData EnsureDraft(IVersionManager versions, ContentVersionRepository versionRepository, Edit.Navigator navigator, NameValueCollection request)
+		public static PathData EnsureDraft(IVersionManager versions, IContentVersionRepository versionRepository, Edit.Navigator navigator, NameValueCollection request)
 		{
 			return EnsureDraft(versions, versionRepository, navigator, key => request[key]);
 		}
 
-		public static PathData EnsureDraft(IVersionManager versions, ContentVersionRepository versionRepository, Edit.Navigator navigator, Func<string, string> requestValueAccessor)
+		public static PathData EnsureDraft(IVersionManager versions, IContentVersionRepository versionRepository, Edit.Navigator navigator, Func<string, string> requestValueAccessor)
 		{
 			var item = navigator.Navigate(requestValueAccessor(PathData.ItemQueryKey));
             return EnsureDraft(versions, versionRepository, requestValueAccessor(PathData.VersionIndexQueryKey), requestValueAccessor(PathData.VersionKeyQueryKey), item);
 		}
 
-		public static PathData EnsureDraft(IVersionManager versions, ContentVersionRepository versionRepository, string versionIndex, string versionKey, ContentItem item)
+		public static PathData EnsureDraft(IVersionManager versions, IContentVersionRepository versionRepository, string versionIndex, string versionKey, ContentItem item)
 		{
 			item = versionRepository.ParseVersion(versionIndex, versionKey, item)
 				?? item;

--- a/src/Framework/N2/Web/UI/WebControls/ItemEditorList.cs
+++ b/src/Framework/N2/Web/UI/WebControls/ItemEditorList.cs
@@ -254,7 +254,7 @@ namespace N2.Web.UI.WebControls
                 
                 if (path.CurrentPage.VersionOf.HasValue)
                 { 
-					var cvr = Engine.Resolve<ContentVersionRepository>();
+					var cvr = Engine.Resolve<IContentVersionRepository>();
 					cvr.Save(path.CurrentPage);
                 }
                 else
@@ -368,7 +368,7 @@ namespace N2.Web.UI.WebControls
                 
                 if (path.CurrentPage.VersionOf.HasValue)
                 { 
-					var cvr = Engine.Resolve<ContentVersionRepository>();
+					var cvr = Engine.Resolve<IContentVersionRepository>();
 					cvr.Save(path.CurrentPage);
                 }
                 else
@@ -418,7 +418,7 @@ namespace N2.Web.UI.WebControls
                     
                     if (path.CurrentPage.VersionOf.HasValue)
                     { 
-					    var cvr = Engine.Resolve<ContentVersionRepository>();
+					    var cvr = Engine.Resolve<IContentVersionRepository>();
 					    cvr.Save(path.CurrentPage);
                     }
                     else
@@ -463,7 +463,7 @@ namespace N2.Web.UI.WebControls
 			if (page.ID == 0 || (!page.VersionOf.HasValue && (page.State == ContentState.New || page.State == ContentState.Draft)))
 				return new PathData(page, item);
 
-			var cvr = Engine.Resolve<ContentVersionRepository>();
+			var cvr = Engine.Resolve<IContentVersionRepository>();
 			var vm = Engine.Resolve<IVersionManager>();
 			var path = PartsExtensions.EnsureDraft(vm, cvr, "", item.GetVersionKey(), item);
 

--- a/src/Framework/N2/Web/WebExtensions.cs
+++ b/src/Framework/N2/Web/WebExtensions.cs
@@ -220,7 +220,7 @@ namespace N2.Web
             return nvc;
         }
 
-        public static ContentItem ParseVersion(this ContentVersionRepository versionRepository, string versionIndexParameterValue, string versionKey, ContentItem masterVersion)
+        public static ContentItem ParseVersion(this IContentVersionRepository versionRepository, string versionIndexParameterValue, string versionKey, ContentItem masterVersion)
         {
             var path = new PathData(Find.ClosestPage(masterVersion), masterVersion);
             if (TryParseVersion(versionRepository, versionIndexParameterValue, versionKey, path))
@@ -230,7 +230,7 @@ namespace N2.Web
             return null;
         }
 
-        public static bool TryParseVersion(this ContentVersionRepository versionRepository, string versionIndexParameterValue, string versionKey, PathData path)
+        public static bool TryParseVersion(this IContentVersionRepository versionRepository, string versionIndexParameterValue, string versionKey, PathData path)
         {
             if (!path.IsEmpty() && !string.IsNullOrEmpty(versionIndexParameterValue))
             {
@@ -241,7 +241,7 @@ namespace N2.Web
             return false;
         }
 
-        public static bool TryApplyVersion(this PathData path, ContentVersion version, string versionKey, ContentVersionRepository repository)
+        public static bool TryApplyVersion(this PathData path, ContentVersion version, string versionKey, IContentVersionRepository repository)
         {
             if (version != null)
             {

--- a/src/Mvc/MvcTemplates/N2/Content/AutoPublish/PublishScheduledAction.cs
+++ b/src/Mvc/MvcTemplates/N2/Content/AutoPublish/PublishScheduledAction.cs
@@ -18,13 +18,13 @@ namespace N2.Edit.AutoPublish
     public class PublishScheduledAction : ScheduledAction
     {
         private readonly Engine.Logger<PublishScheduledAction> logger;
-        private ContentVersionRepository versionRepository;
+        private IContentVersionRepository versionRepository;
         private IVersionManager versioner;
         private IPersister persister;
         private ISecurityManager security;
         private StateChanger changer;
         
-        public PublishScheduledAction(ContentVersionRepository versionRepository, IVersionManager versioner, IPersister persister, ISecurityManager security, StateChanger changer)
+        public PublishScheduledAction(IContentVersionRepository versionRepository, IVersionManager versioner, IPersister persister, ISecurityManager security, StateChanger changer)
         {
             this.versionRepository = versionRepository;
             this.versioner = versioner;

--- a/src/Mvc/MvcTemplates/N2/Content/Edit.aspx.cs
+++ b/src/Mvc/MvcTemplates/N2/Content/Edit.aspx.cs
@@ -58,7 +58,7 @@ namespace N2.Edit
 		protected CommandDispatcher Commands;
 		protected IEditManager EditManager;
 		protected IEditUrlManager ManagementPaths;
-		protected ContentVersionRepository Repository;
+		protected IContentVersionRepository Repository;
 
 		protected override void OnPreInit(EventArgs e)
 		{
@@ -69,7 +69,7 @@ namespace N2.Edit
 			Commands = Engine.Resolve<CommandDispatcher>();
 			EditManager = Engine.EditManager;
 			ManagementPaths = Engine.ManagementPaths;
-			Repository = Engine.Resolve<ContentVersionRepository>();
+			Repository = Engine.Resolve<IContentVersionRepository>();
 		}
 
 		protected override void OnInit(EventArgs e)

--- a/src/Mvc/MvcTemplates/N2/Files/FileSystem/Directory.aspx.cs
+++ b/src/Mvc/MvcTemplates/N2/Files/FileSystem/Directory.aspx.cs
@@ -168,7 +168,7 @@ namespace N2.Edit.FileSystem
 				//Get a specific version of the item if version index and key are provided.
 				if (!string.IsNullOrWhiteSpace(versionIndex) && !string.IsNullOrWhiteSpace(versionKey))
 				{
-					var cvr = Engine.Resolve<ContentVersionRepository>();
+					var cvr = Engine.Resolve<IContentVersionRepository>();
 					item = cvr.ParseVersion(versionIndex, versionKey, item);
 				}
 
@@ -224,7 +224,7 @@ namespace N2.Edit.FileSystem
 			//Get a specific version of the item if version index and key are provided.
 			if (!string.IsNullOrWhiteSpace(versionIndex) && !string.IsNullOrWhiteSpace(versionKey))
 			{
-				var cvr = Engine.Resolve<ContentVersionRepository>();
+				var cvr = Engine.Resolve<IContentVersionRepository>();
 				item = cvr.ParseVersion(versionIndex, versionKey, item);
 			}
 
@@ -253,7 +253,7 @@ namespace N2.Edit.FileSystem
 
 				if (item.VersionOf.HasValue)
 				{
-					var cvr = Engine.Resolve<ContentVersionRepository>();
+					var cvr = Engine.Resolve<IContentVersionRepository>();
 					cvr.Save(item);
 				}
 				else

--- a/src/Mvc/MvcTemplates/N2/Installation/UpgradeVersionWorker.cs
+++ b/src/Mvc/MvcTemplates/N2/Installation/UpgradeVersionWorker.cs
@@ -12,10 +12,10 @@ namespace N2.Management.Installation
     [Service]
     public class UpgradeVersionWorker
     {
-        private ContentVersionRepository versionRepository;
+        private IContentVersionRepository versionRepository;
         private IContentItemRepository itemRepository;
 
-        public UpgradeVersionWorker(ContentVersionRepository versionRepository, IContentItemRepository itemRepository)
+        public UpgradeVersionWorker(IContentVersionRepository versionRepository, IContentItemRepository itemRepository)
         {
             this.versionRepository = versionRepository;
             this.itemRepository = itemRepository;

--- a/src/Mvc/MvcTemplates/N2/Myself/Statistics.ascx.cs
+++ b/src/Mvc/MvcTemplates/N2/Myself/Statistics.ascx.cs
@@ -34,7 +34,7 @@ namespace N2.Management.Myself
             PageFilter.FilterPages(items);
             lblPages.Text = items.Count.ToString();
 
-            long totalCount = itemsCount + Engine.Resolve<ContentVersionRepository>().Repository.Count();
+            long totalCount = itemsCount + Engine.Resolve<IContentVersionRepository>().Repository.Count();
                 //Find.Items.All.PreviousVersions(N2.Persistence.Finder.VersionOption.Include).Select().Count;
             lblVersionsRatio.Text = string.Format("{0:F2}", (double)totalCount / (double)itemsCount);
 

--- a/src/Mvc/MvcTemplates/N2/Web/UI/Controls/ItemLink.cs
+++ b/src/Mvc/MvcTemplates/N2/Web/UI/Controls/ItemLink.cs
@@ -33,7 +33,7 @@ namespace N2.Edit.Web.UI.Controls
 				var version = DataSource as ContentVersion;
 				if (version != null)
 				{
-					item = version.GetVersionInfo(N2.Context.Current.Resolve<ContentVersionRepository>()).Content;
+					item = version.GetVersionInfo(N2.Context.Current.Resolve<IContentVersionRepository>()).Content;
 				}
 
 				return;


### PR DESCRIPTION
Introduced IContentVersionRepository interface in order to be able to use dependency injection to use a separate repository just for handling ContentVersions.